### PR TITLE
fix: correct dependabot ignore block indentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,10 +23,10 @@ updates:
     directory: "/"
     multi-ecosystem-group: "module"
     patterns: ["*"]
-      ignore:
-        - dependency-name: "hashicorp/*"
-          update-types: ["version-update:semver-major"]
-        - dependency-name: "microsoft/*"
-          update-types: ["version-update:semver-major"]
-        - dependency-name: "azure/*"
-          update-types: ["version-update:semver-major"]
+    ignore:
+      - dependency-name: "hashicorp/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "microsoft/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "azure/*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

- Fixes the `ignore` stanza indentation in `.github/dependabot.yml` for the `terraform` package-ecosystem
- The `ignore` block was incorrectly nested under `schedule`/`patterns`, which prevented dependabot from applying the semver-major ignore rules for `hashicorp/*`, `microsoft/*`, and `azure/*` providers
- Moves `ignore` to be a direct property of the package-ecosystem entry at the correct YAML indentation level

## Test plan

- [ ] Dependabot configuration is valid YAML
- [ ] CI/workflow checks pass
- [ ] Dependabot recognizes the ignore rules after merge

🤖 Generated with [Claude Code](https://claude.ai/code)